### PR TITLE
feat: add defaultAsBreadcrumb option

### DIFF
--- a/packages/nestjs-sentry/lib/sentry.interfaces.ts
+++ b/packages/nestjs-sentry/lib/sentry.interfaces.ts
@@ -5,7 +5,7 @@ import {
   Type
 } from '@nestjs/common/interfaces';
 import { Integration, Options } from '@sentry/types';
-import { ConsoleLoggerOptions } from '@nestjs/common';
+import { ConsoleLoggerOptions, LogLevel } from '@nestjs/common';
 import { SeverityLevel } from '@sentry/node';
 
 export interface SentryCloseOptions {
@@ -14,9 +14,12 @@ export interface SentryCloseOptions {
   timeout?: number;
 }
 
+type NonErrorLogLevel = Exclude<LogLevel, 'error' | 'fatal'>;
+
 export type SentryModuleOptions = Omit<Options, 'integrations'> & {
   integrations?: Integration[];
   close?: SentryCloseOptions;
+  defaultAsBreadcrumb?: NonErrorLogLevel[];
 } & ConsoleLoggerOptions;
 
 export interface SentryOptionsFactory {

--- a/packages/nestjs-sentry/lib/sentry.service.ts
+++ b/packages/nestjs-sentry/lib/sentry.service.ts
@@ -19,6 +19,7 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
       // console.log('options not found. Did you use SentryModule.forRoot?');
       return;
     }
+
     if (!SentryService.serviceInstance) {
       SentryService.serviceInstance = this;
     }
@@ -56,7 +57,7 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
     message = `${this.app} ${message}`;
     try {
       super.log(message, context);
-      asBreadcrumb
+      asBreadcrumb === true || this.opts?.defaultAsBreadcrumb?.includes('log')
         ? Sentry.addBreadcrumb({
             message,
             level: Severity.Log,
@@ -80,7 +81,7 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
     message = `${this.app} ${message}`;
     try {
       super.warn(message, context);
-      asBreadcrumb
+      asBreadcrumb === true || this.opts?.defaultAsBreadcrumb?.includes('warn')
         ? Sentry.addBreadcrumb({
             message,
             level: Severity.Warning,
@@ -96,7 +97,7 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
     message = `${this.app} ${message}`;
     try {
       super.debug(message, context);
-      asBreadcrumb
+      asBreadcrumb === true || this.opts?.defaultAsBreadcrumb?.includes('debug')
         ? Sentry.addBreadcrumb({
             message,
             level: Severity.Debug,
@@ -112,7 +113,7 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
     message = `${this.app} ${message}`;
     try {
       super.verbose(message, context);
-      asBreadcrumb
+      asBreadcrumb === true || this.opts?.defaultAsBreadcrumb?.includes('verbose')
         ? Sentry.addBreadcrumb({
             message,
             level: Severity.Info,

--- a/packages/nestjs-sentry/lib/sentry.service.ts
+++ b/packages/nestjs-sentry/lib/sentry.service.ts
@@ -19,6 +19,10 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
       // console.log('options not found. Did you use SentryModule.forRoot?');
       return;
     }
+    if (!SentryService.serviceInstance) {
+      SentryService.serviceInstance = this;
+    }
+
     const { integrations = [], ...sentryOptions } = opts;
     Sentry.init({
       ...sentryOptions,


### PR DESCRIPTION
## Motivation
Currently, all logs are sent by default to Sentry, unless we explictly pass `true` to `asBreadcrumb` to the logger method. This is impractical, and also causes issues for framework level log (such as nestjs route explorer).

## Solution
Introduce a non-breaking `defaultAsBreadcrumb` option. It takes in a non-error level log array to define which method should default to breadcrumb (in opposition to capturing an event)

### Example Usage

```
SentryModule.forRoot({
      dsn:  // DSN
      enabled: true,
      defaultAsBreadcrumb: ['warn', 'log', 'debug', 'verbose'],
    }),
```

## Caveats
The `SentryServiceInstance` method returns a new `SentryService` in which the options are undefined. To fix, it was necessary to set the instance in the constructor (when the options have been specified). This seems to work well but unsure of any side-effects within the package