### PR TITLE
Bawahakim/logger level

### DIFF
--- a/packages/nestjs-sentry/lib/sentry.service.ts
+++ b/packages/nestjs-sentry/lib/sentry.service.ts
@@ -19,6 +19,10 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
       // console.log('options not found. Did you use SentryModule.forRoot?');
       return;
     }
+    if (!SentryService.serviceInstance) {
+      SentryService.serviceInstance = this;
+    }
+
     const { integrations = [], ...sentryOptions } = opts;
     Sentry.init({
       ...sentryOptions,

--- a/packages/nestjs-sentry/lib/sentry.service.ts
+++ b/packages/nestjs-sentry/lib/sentry.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, ConsoleLogger } from '@nestjs/common';
+import { Inject, Injectable, ConsoleLogger, LogLevel } from '@nestjs/common';
 import { OnApplicationShutdown } from '@nestjs/common';
 import { ClientOptions, Client } from '@sentry/types';
 import * as Sentry from '@sentry/node';
@@ -53,6 +53,8 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   }
 
   log(message: string, context?: string, asBreadcrumb?: boolean) {
+    if (!this._shouldLog('log')) return;
+
     message = `${this.app} ${message}`;
     try {
       super.log(message, context);
@@ -69,6 +71,8 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   }
 
   error(message: string, trace?: string, context?: string) {
+    if (!this._shouldLog('error')) return;
+
     message = `${this.app} ${message}`;
     try {
       super.error(message, trace, context);
@@ -77,6 +81,8 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   }
 
   warn(message: string, context?: string, asBreadcrumb?: boolean) {
+    if (!this._shouldLog('warn')) return;
+
     message = `${this.app} ${message}`;
     try {
       super.warn(message, context);
@@ -93,6 +99,8 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   }
 
   debug(message: string, context?: string, asBreadcrumb?: boolean) {
+    if (!this._shouldLog('debug')) return;
+
     message = `${this.app} ${message}`;
     try {
       super.debug(message, context);
@@ -109,6 +117,8 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   }
 
   verbose(message: string, context?: string, asBreadcrumb?: boolean) {
+    if (!this._shouldLog('verbose')) return;
+
     message = `${this.app} ${message}`;
     try {
       super.verbose(message, context);
@@ -132,5 +142,10 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
     if (this.opts?.close?.enabled === true) {
       await Sentry.close(this.opts?.close.timeout);
     }
+  }
+
+  private _shouldLog(level: LogLevel) {
+    if (!this.opts?.logLevels) return true;
+    return this.opts?.logLevels?.includes(level);
   }
 }


### PR DESCRIPTION
## Motivation
The `logLevels` option currently seem useless when using `SentryService` as the logger. It would be convenient if we could specify the log levels to log.

## Solution
Uses the build in `logLevels` option to decide if a method should log or not (including sending to sentry/adding breadcrumbs)

## Caveat
The `SentryServiceInstance` method returns a new SentryService in which the options are undefined. To fix, it was necessary to set the instance in the constructor (when the options have been specified). This seems to work well but unsure of any side-effects within the package. Cherry-picked from #5 